### PR TITLE
Change disqus id

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-  var disqus_shortname = 'pullrequest';
+  var disqus_shortname = 'pullrequestorg';
   var disqus_identifier = '{{ post.id }}';
   $.getScript("http://pullrequest.disqus.com/embed.js");
 </script>


### PR DESCRIPTION
Actually pullrequests.org use disqus id of http://losohome.com/pullrequest. So if I comment on an article (for example on http://pullrequest.org/2012/08/21/au-coeur-d-elasticsearch.html), you will never see the comments.
You should create another disqus account and change this settings.
Cheers.
